### PR TITLE
Limiting number of multiprocessing threads/cores

### DIFF
--- a/pyevolve/GPopulation.py
+++ b/pyevolve/GPopulation.py
@@ -151,13 +151,13 @@ class GPopulation:
       self.allSlots      = [self.scaleMethod]
 
       self.internalParams = {}
-      self.multiProcessing = (False, False)
+      self.multiProcessing = (False, False, False)
 
       # Statistics
       self.statted = False
       self.stats   = Statistics()
 
-   def setMultiProcessing(self, flag=True, full_copy=False):
+   def setMultiProcessing(self, flag=True, full_copy=False, limit_cores=False):
       """ Sets the flag to enable/disable the use of python multiprocessing module.
       Use this option when you have more than one core on your CPU and when your
       evaluation function is very slow.
@@ -167,6 +167,7 @@ class GPopulation:
       
       :param flag: True (default) or False
       :param full_copy: True or False (default)
+      :param limit_cores: Number of cores to use or just all use them all (default)
 
       .. warning:: Use this option only when your evaluation function is slow, se you
                    will get a good tradeoff between the process communication speed and the
@@ -176,7 +177,7 @@ class GPopulation:
          The `setMultiProcessing` method.
 
       """
-      self.multiProcessing = (flag, full_copy)
+      self.multiProcessing = (flag, full_copy, limit_cores)
    
    def setMinimax(self, minimax):
       """ Sets the population minimax
@@ -362,7 +363,15 @@ class GPopulation:
       # We have multiprocessing
       if self.multiProcessing[0] and MULTI_PROCESSING:
          logging.debug("Evaluating the population using the multiprocessing method")
-         proc_pool = Pool()
+
+         # Check for the numer of cores to use
+         if self.multipProcessing[2] is not False and (self.multiProcessing[2] <= CPU_COUNT and self.multiProcessing[2] > 0):
+            proc_pool = Pool(processes=self.multiProcessing[2])
+            logging.debug("You have limited the number of cores to be used to %d out of %d CPU cores available" % (self.multiprocessing[2], CPU_COUNT))
+         else:
+            proc_pool = Pool(processes=CPU_COUNT)
+            logging.debug("Warning: Too many cores requested!  You asked for %d out of %d CPU cores available, so defaulting back to using all of them." % (self.multiprocessing[2], CPU_COUNT))
+            
 
          # Multiprocessing full_copy parameter
          if self.multiProcessing[1]:

--- a/pyevolve/GPopulation.py
+++ b/pyevolve/GPopulation.py
@@ -365,9 +365,9 @@ class GPopulation:
          logging.debug("Evaluating the population using the multiprocessing method")
 
          # Check for the numer of cores to use
-         if self.multipProcessing[2] is not False and (self.multiProcessing[2] <= CPU_COUNT and self.multiProcessing[2] > 0):
+         if self.multiProcessing[2] is not False and (self.multiProcessing[2] <= CPU_COUNT and self.multiProcessing[2] > 0):
             proc_pool = Pool(processes=self.multiProcessing[2])
-            logging.debug("You have limited the number of cores to be used to %d out of %d CPU cores available" % (self.multiprocessing[2], CPU_COUNT))
+            logging.debug("You have limited the number of cores to be used to %d out of %d CPU cores available" % (self.multiProcessing[2], CPU_COUNT))
          else:
             proc_pool = Pool(processes=CPU_COUNT)
             logging.debug("Warning: Too many cores requested!  You asked for %d out of %d CPU cores available, so defaulting back to using all of them." % (self.multiprocessing[2], CPU_COUNT))

--- a/pyevolve/GSimpleGA.py
+++ b/pyevolve/GSimpleGA.py
@@ -72,7 +72,7 @@ import random
 import logging
 
 from time  import time
-from types import BooleanType
+from types import BooleanType, IntType
 from sys   import platform as sys_platform
 from sys   import stdout as sys_stdout
 
@@ -381,7 +381,7 @@ class GSimpleGA:
       ret+="\n"
       return ret
    
-   def setMultiProcessing(self, flag=True, full_copy=False):
+   def setMultiProcessing(self, flag=True, full_copy=False, limit_cores=False):
       """ Sets the flag to enable/disable the use of python multiprocessing module.
       Use this option when you have more than one core on your CPU and when your
       evaluation function is very slow.
@@ -401,6 +401,7 @@ class GSimpleGA:
       
       :param flag: True (default) or False
       :param full_copy: True or False (default)
+      :param limit_cores: Number of cores to use or just use them all (default)
 
       .. warning:: Use this option only when your evaluation function is slow, so you'll
                    get a good tradeoff between the process communication speed and the
@@ -422,7 +423,11 @@ class GSimpleGA:
       if type(full_copy) != BooleanType:
          Util.raiseException("Multiprocessing 'full_copy' option must be True or False", TypeError)
 
-      self.internalPop.setMultiProcessing(flag, full_copy)
+      if type(limit_cores) != BooleanType:
+         if type(limit_cores) != IntType:
+            Util.raiseException("Multiprocessing 'limit_cores' option must be either False or an Integer number of processes to spawn", TypeError)
+
+      self.internalPop.setMultiProcessing(flag, full_copy, limit_cores)
 
    def setMigrationAdapter(self, migration_adapter=None):
       """ Sets the Migration Adapter


### PR DESCRIPTION
This is a rehash of something I put on the old trac system.  It's a simple way to limit the number of spawned processes in the multiprocessing module via a simple keyword argument, and it's worked great for me on a multiuser machine.  I think I've added the documentation to the right places in the two changed files already.
