### PR TITLE
Fix pep8 warning about using the deprecated form of 'raise'.

### DIFF
--- a/pyevolve/Migration.py
+++ b/pyevolve/Migration.py
@@ -273,7 +273,7 @@ class MPIMigration(MigrationScheme):
    def __init__(self):
       # Delayed ImportError of mpi4py
       if not HAS_MPI4PY:
-         raise ImportError, "No module named mpi4py, you must install mpi4py to use MPIMIgration !"
+         raise ImportError("No module named mpi4py, you must install mpi4py to use MPIMIgration!")
 
       super(MPIMigration, self).__init__()
 


### PR DESCRIPTION
This is a fairly obvious one!  Picked up with pep8(1).
