### PR TITLE
Add an optional max_processes parameter to setMultiProcessing()

### DIFF
--- a/pyevolve/GPopulation.py
+++ b/pyevolve/GPopulation.py
@@ -152,13 +152,13 @@ class GPopulation:
       self.allSlots = [self.scaleMethod]
 
       self.internalParams = {}
-      self.multiProcessing = (False, False)
+      self.multiProcessing = (False, False, None)
 
       # Statistics
       self.statted = False
       self.stats = Statistics()
 
-   def setMultiProcessing(self, flag=True, full_copy=False):
+   def setMultiProcessing(self, flag=True, full_copy=False, max_processes=None):
       """ Sets the flag to enable/disable the use of python multiprocessing module.
       Use this option when you have more than one core on your CPU and when your
       evaluation function is very slow.
@@ -168,6 +168,7 @@ class GPopulation:
 
       :param flag: True (default) or False
       :param full_copy: True or False (default)
+      :param max_processes: None (default) or an integer value
 
       .. warning:: Use this option only when your evaluation function is slow, se you
                    will get a good tradeoff between the process communication speed and the
@@ -177,7 +178,7 @@ class GPopulation:
          The `setMultiProcessing` method.
 
       """
-      self.multiProcessing = (flag, full_copy)
+      self.multiProcessing = (flag, full_copy, max_processes)
 
    def setMinimax(self, minimax):
       """ Sets the population minimax
@@ -385,7 +386,7 @@ class GPopulation:
       # We have multiprocessing
       if self.multiProcessing[0] and MULTI_PROCESSING:
          logging.debug("Evaluating the population using the multiprocessing method")
-         proc_pool = Pool()
+         proc_pool = Pool(processes=self.multiProcessing[2])
 
          # Multiprocessing full_copy parameter
          if self.multiProcessing[1]:

--- a/pyevolve/GSimpleGA.py
+++ b/pyevolve/GSimpleGA.py
@@ -383,7 +383,7 @@ class GSimpleGA:
         ret += "\n"
         return ret
 
-    def setMultiProcessing(self, flag=True, full_copy=False):
+    def setMultiProcessing(self, flag=True, full_copy=False, max_processes=None):
         """ Sets the flag to enable/disable the use of python multiprocessing module.
         Use this option when you have more than one core on your CPU and when your
         evaluation function is very slow.
@@ -403,6 +403,7 @@ class GSimpleGA:
 
         :param flag: True (default) or False
         :param full_copy: True or False (default)
+        :param max_processes: None (default) or an integer value
 
         .. warning:: Use this option only when your evaluation function is slow, so you'll
                      get a good tradeoff between the process communication speed and the
@@ -424,7 +425,7 @@ class GSimpleGA:
         if type(full_copy) != BooleanType:
             Util.raiseException("Multiprocessing 'full_copy' option must be True or False", TypeError)
 
-        self.internalPop.setMultiProcessing(flag, full_copy)
+        self.internalPop.setMultiProcessing(flag, full_copy, max_processes)
 
     def setMigrationAdapter(self, migration_adapter=None):
         """ Sets the Migration Adapter


### PR DESCRIPTION
This patch adds an optional parameter to setMultiProcessing() to control the number of worker processes in the pool.  Defaults to None, which leads to one worker for every CPU available (as the Python multiprocessing module does).  On some multi-user systems, it is not polite to spawn that many workers.
