### PR TITLE
Change incorrect description of mutation rate

### DIFF
--- a/pyevolve/GSimpleGA.py
+++ b/pyevolve/GSimpleGA.py
@@ -16,7 +16,7 @@ Default Parameters
 
 *Mutation Rate*
 
-   Default is 0.02, which represents 0.2%
+   Default is 0.02, which represents 2%
 
 *Crossover Rate*
 


### PR DESCRIPTION
As far as I can understand from reading the Mutations.py code, a Mutation rate of 0.02 means a 2% mutation rate, not a 0.2% mutation rate. This also agrees with what is stated in the following example: http://blog.christianperone.com/2009/10/successful-pyevolve-multiprocessing-speedup-for-genetic-programming/