### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/source/getstarted.rst
+++ b/docs/source/getstarted.rst
@@ -160,7 +160,7 @@ module.
 
 .. warning:: note that the Interactive Mode for Linux/Mac was disabled in the
              0.6 release of Pyevolve. The cause was the platform dependant code.
-             To use it in Linux/Mac you must set the generation in wich Pyevolve
+             To use it in Linux/Mac you must set the generation in which Pyevolve
              will enter in the Interactive Mode by using :meth:`GSimpleGA.GSimpleGA.setInteractiveGeneration`
              method; see the :mod:`Interaction` module documentation for more information.
 

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -299,7 +299,7 @@ Sites
    A book, freely downloadable under a Creative Commons license.
 
 `The Genetic Programming Bibliography <http://www.cs.bham.ac.uk/~wbl/biblio/README.html>`_
-   A very interesting initiative mantained by William Langdon, Steven Gustafson, and John Koza.
+   A very interesting initiative maintained by William Langdon, Steven Gustafson, and John Koza.
    Over than 6000 GP references !
 
 
@@ -401,7 +401,7 @@ To install Pyevolve in PyS60 you simple need to copy the "pyevolve" package (you
 or even the "pyevolve" of your Python installation to the smartphone in a place that PyS60 can find it, usually
 in :file:`c:\\resource\\Python25`, for more information read the PyS60 documentation. The Genetic Algorithms and the
 Genetic Programming cores of Pyevolve was tested with PyS60 2.0, but to use Genetic Programming, you must
-explicitly define the funtions of the GP, like in :ref:`snippet_gp_explicit`.
+explicitly define the functions of the GP, like in :ref:`snippet_gp_explicit`.
 
 Of course not all features of Pyevolve are supported in PyS60, for example some DBAdapters and the graphical
 plotting tool, since no matplotlib port is available to PyS60 at the moment. Pyevolve was tested with PyS60 2.0

--- a/pyevolve/Consts.py
+++ b/pyevolve/Consts.py
@@ -10,7 +10,7 @@ General constants
 
 .. attribute:: CDefPythonRequire
 
-   The mininum version required to run Pyevolve.
+   The minimum version required to run Pyevolve.
 
 .. attribute:: CDefLogFile
 
@@ -89,7 +89,7 @@ Scaling scheme constants (:mod:`Scaling`)
 
 .. attribute:: CDefScaleBoltzMinTemp
 
-   The default mininum temperature of the (:func:`Scaling.BoltzmannScaling`) scaling scheme factor.
+   The default minimum temperature of the (:func:`Scaling.BoltzmannScaling`) scaling scheme factor.
 
 .. attribute:: CDefScaleBoltzFactor
 

--- a/pyevolve/DBAdapters.py
+++ b/pyevolve/DBAdapters.py
@@ -452,7 +452,7 @@ class DBXMLRPC(DBBaseAdapter):
       :param frequency: the generational dump frequency
 
 
-   .. note:: The XML RPC Server must implement the *insert* method, wich receives
+   .. note:: The XML RPC Server must implement the *insert* method, which receives
              a python dictionary as argument.
 
    Example of an server in Python: ::

--- a/pyevolve/G1DBinaryString.py
+++ b/pyevolve/G1DBinaryString.py
@@ -151,7 +151,7 @@ class G1DBinaryString(G1DBase):
       G1DBase.copy(self, g)
 
    def clone(self):
-      """ Return a new instace copy of the genome
+      """ Return a new instance copy of the genome
 
       Example:
          >>> g = G1DBinaryString(5)

--- a/pyevolve/G1DList.py
+++ b/pyevolve/G1DList.py
@@ -155,7 +155,7 @@ class G1DList(G1DBase):
         G1DBase.copy(self, g)
 
     def clone(self):
-        """ Return a new instace copy of the genome
+        """ Return a new instance copy of the genome
 
         :rtype: the G1DList clone instance
 

--- a/pyevolve/G2DBinaryString.py
+++ b/pyevolve/G2DBinaryString.py
@@ -186,7 +186,7 @@ class G2DBinaryString(GenomeBase):
             g.genomeString[i] = self.genomeString[i][:]
 
     def clone(self):
-        """ Return a new instace copy of the genome
+        """ Return a new instance copy of the genome
 
         :rtype: the G2DBinaryString clone instance
 

--- a/pyevolve/G2DList.py
+++ b/pyevolve/G2DList.py
@@ -218,7 +218,7 @@ class G2DList(GenomeBase):
             g.genomeList[i] = self.genomeList[i][:]
 
     def clone(self):
-        """ Return a new instace copy of the genome
+        """ Return a new instance copy of the genome
 
         :rtype: the G2DList clone instance
 

--- a/pyevolve/GAllele.py
+++ b/pyevolve/GAllele.py
@@ -198,7 +198,7 @@ class GAlleleRange(object):
       self.__processMinMax()
 
    def __processMinMax(self):
-      """ Process the mininum and maximum of the Allele """
+      """ Process the minimum and maximum of the Allele """
       self.minimum = min([x for x, y in self.beginEnd])
       self.maximum = max([y for x, y in self.beginEnd])
 

--- a/pyevolve/GPopulation.py
+++ b/pyevolve/GPopulation.py
@@ -2,7 +2,7 @@
 :mod:`GPopulation` -- the population module
 ================================================================
 
-This module contains the :class:`GPopulation.GPopulation` class, which is reponsible
+This module contains the :class:`GPopulation.GPopulation` class, which is responsible
 to keep the population and the statistics.
 
 Default Parameters

--- a/pyevolve/GSimpleGA.py
+++ b/pyevolve/GSimpleGA.py
@@ -5,7 +5,7 @@
 
 This module contains the GA Engine, the GA Engine class is responsible
 for all the evolutionary process. It contains the GA Engine related
-funtions, like the Termination Criteria functions for convergence analysis, etc.
+functions, like the Termination Criteria functions for convergence analysis, etc.
 
 Default Parameters
 -------------------------------------------------------------
@@ -134,7 +134,7 @@ def RawStatsCriteria(ga_engine):
 
 
 def FitnessStatsCriteria(ga_engine):
-    """ Terminate the evoltion based on the fitness stats
+    """ Terminate the evolution based on the fitness stats
 
     Example:
        >>> ga_engine.terminationCriteria.set(GSimpleGA.FitnessStatsCriteria)
@@ -388,7 +388,7 @@ class GSimpleGA(object):
         Use this option when you have more than one core on your CPU and when your
         evaluation function is very slow.
 
-        Pyevolve will automaticly check if your Python version has **multiprocessing**
+        Pyevolve will automatically check if your Python version has **multiprocessing**
         support and if you have more than one single CPU core. If you don't have support
         or have just only one core, Pyevolve will not use the **multiprocessing**
         feature.

--- a/pyevolve/GTree.py
+++ b/pyevolve/GTree.py
@@ -444,7 +444,7 @@ class GTreeGP(GTreeBase):
         return count
 
     def getSExpression(self, start_node=None):
-        """ Returns a tree-formated string (s-expression) of the tree.
+        """ Returns a tree-formatted string (s-expression) of the tree.
 
         :rtype: a S-Expression representing the tree
         """

--- a/pyevolve/GenomeBase.py
+++ b/pyevolve/GenomeBase.py
@@ -486,7 +486,7 @@ class GTreeBase(GenomeBase):
       return count
 
    def getTraversalString(self, start_node=None, spc=0):
-      """ Returns a tree-formated string of the tree. This
+      """ Returns a tree-formatted string of the tree. This
       method is used by the __repr__ method of the tree
 
       :rtype: a string representing the tree

--- a/pyevolve/Scaling.py
+++ b/pyevolve/Scaling.py
@@ -82,7 +82,7 @@ def BoltzmannScaling(pop):
    population parameters, this parameter will set the start temperature. You
    can specify the **boltz_factor** and the **boltz_min** parameters, the **boltz_factor**
    is the value that the temperature will be subtracted and the **boltz_min** is the
-   mininum temperature of the scaling scheme.
+   minimum temperature of the scaling scheme.
 
    .. versionadded: 0.6
       The `BoltzmannScaling` function.

--- a/pyevolve/Statistics.py
+++ b/pyevolve/Statistics.py
@@ -3,7 +3,7 @@
 :mod:`Statistics` -- statistical structure module
 ==========================================================================
 
-This module have the class which is reponsible to keep statistics of each
+This module have the class which is responsible to keep statistics of each
 generation. This class is used by the adapters and other statistics dump objects.
 
 """
@@ -21,7 +21,7 @@ class Statistics(object):
        Standard Deviation and Variance of raw scores
 
     **fitMax, fitMin, fitAve**
-       Maximum, mininum and average of fitness scores
+       Maximum, minimum and average of fitness scores
 
     **rawTot, fitTot**
        The total (sum) of raw scores and the fitness scores


### PR DESCRIPTION
There are small typos in:
- docs/source/getstarted.rst
- docs/source/intro.rst
- pyevolve/Consts.py
- pyevolve/DBAdapters.py
- pyevolve/G1DBinaryString.py
- pyevolve/G1DList.py
- pyevolve/G2DBinaryString.py
- pyevolve/G2DList.py
- pyevolve/GAllele.py
- pyevolve/GPopulation.py
- pyevolve/GSimpleGA.py
- pyevolve/GTree.py
- pyevolve/GenomeBase.py
- pyevolve/Scaling.py
- pyevolve/Statistics.py

Fixes:
- Should read `minimum` rather than `mininum`.
- Should read `instance` rather than `instace`.
- Should read `which` rather than `wich`.
- Should read `responsible` rather than `reponsible`.
- Should read `functions` rather than `funtions`.
- Should read `formatted` rather than `formated`.
- Should read `maintained` rather than `mantained`.
- Should read `evolution` rather than `evoltion`.
- Should read `automatically` rather than `automaticly`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md